### PR TITLE
Fixing multiple grid CSS issue and block editor invalid parameter issue

### DIFF
--- a/inc/schedule-output-functions.php
+++ b/inc/schedule-output-functions.php
@@ -370,8 +370,8 @@ function wpcs_scheduleOutput( $props ) {
 			'post_type'      => 'wpcs_session',
 			'posts_per_page' => - 1,
 			'meta_key' => '_wpcs_session_time',
-    	'orderby' => 'meta_value_num',
-    	'order' => 'ASC',
+			'orderby' => 'meta_value_num',
+			'order' => 'ASC',
 			'meta_query'     => array(
 				'relation' => 'AND',
 				array(
@@ -427,7 +427,7 @@ function wpcs_scheduleOutput( $props ) {
 
 		$html .= '<style>
 		@media screen and (min-width:700px) {
-			.wpcs-layout-grid {
+			#wpcs_'.$array_times[0].'.wpcs-layout-grid {
 				display: grid;
 				grid-gap: 1em;
 				grid-template-rows:
@@ -466,7 +466,7 @@ function wpcs_scheduleOutput( $props ) {
 		</style>';
 
 		// Schedule Wrapper
-		$html .= '<div class="schedule wpcs-schedule wpcs-color-scheme-'.$attr['color_scheme'].' wpcs-layout-'.$attr['layout'].'" aria-labelledby="schedule-heading">';
+		$html .= '<div id="wpcs_'.$array_times[0].'" class="schedule wpcs-schedule wpcs-color-scheme-'.$attr['color_scheme'].' wpcs-layout-'.$attr['layout'].'" aria-labelledby="schedule-heading">';
 
 			// Track Titles
 			if($tracks){

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://roadwarriorcreative.com/donate
 Tags: conference schedule, conference, schedule, event schedule, event, events, block, blocks, gutenberg, sessions, speakers, events, events calendar
 Requires at least: 5.0.0
 Tested up to: 5.6
-Stable tag: 1.0.8
+Stable tag: 1.0.9
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -90,6 +90,10 @@ Yes! We want to make our plugin work for you. If you need help regarding customi
 5. screenshot-5.png shows what the schedule looks like on mobile screens.
 
 == Changelog ==
+
+= 1.0.9 =
+* Added a custom ID to schedules with the Grid layout and used that for the generated CSS to allow multiple Grid layout schedules on the same page
+* Fixed an error in the Block Editor preview showing Invalid parameter(s): attributes. Block Editor previews now show properly
 
 = 1.0.8 =
 * Freemius Updated

--- a/wp-conference-schedule.php
+++ b/wp-conference-schedule.php
@@ -97,6 +97,7 @@ class WP_Conference_Schedule_Plugin {
 			'attributes' => array(
 				'date' => array('type' => 'string'),
 				'color_scheme' => array('type' => 'string'),
+				'layout' => array('type' => 'string'),
 				'session_link' => array('type' => 'string'),
 				'tracks' => array('type' => 'string'),
 				'align' => array('type' => 'string'),
@@ -143,9 +144,9 @@ class WP_Conference_Schedule_Plugin {
 		// Enqueues scripts and styles for session admin page
 		if ( 'wpcs_session' == $post_type ) {
 			wp_enqueue_script( 'jquery-ui-datepicker' );
-    	wp_register_style( 'jquery-ui', plugins_url( '/assets/css/jquery-ui.css', __FILE__ ) );
+			wp_register_style( 'jquery-ui', plugins_url( '/assets/css/jquery-ui.css', __FILE__ ) );
 
-    	wp_enqueue_style( 'jquery-ui' ); 
+			wp_enqueue_style( 'jquery-ui' ); 
 		}
 
 	}
@@ -422,12 +423,12 @@ class WP_Conference_Schedule_Plugin {
 	 * Enqueue blocks
 	 */
 	function wpcs_loadBlockFiles() {
-	  wp_enqueue_script(
-	    'schedule-block',
-	    plugin_dir_url(__FILE__) . 'assets/js/schedule-block.js',
-	    array('wp-blocks', 'wp-i18n', 'wp-editor'),
-	    true
-	  );
+		wp_enqueue_script(
+			'schedule-block',
+			plugin_dir_url(__FILE__) . 'assets/js/schedule-block.js',
+			array('wp-blocks', 'wp-i18n', 'wp-editor'),
+			true
+		);
 	}
 
 	/**

--- a/wp-conference-schedule.php
+++ b/wp-conference-schedule.php
@@ -9,7 +9,7 @@
  * Plugin Name:       WP Conference Schedule
  * Plugin URI:        https://wpconferenceschedule.com
  * Description:       Creates sessions post types for conference websites. Includes shortcode and custom block for fully mobile-responsive conference schedule in table format.
- * Version:           1.0.8
+ * Version:           1.0.9
  * Author:            Road Warrior Creative
  * Author URI:        https://roadwarriorcreative.com
  * License:           GPL-2.0+


### PR DESCRIPTION
This Pull Request addresses the issues brought up in posts on the WordPress.org support forums listed below:

https://wordpress.org/support/topic/css-grid-row-classes-not-being-generated-properly/
https://wordpress.org/support/topic/error-loading-block-invalid-parameters-attributes-5/

Both of these issues are now resolved in this pull request.